### PR TITLE
 Add Dockerfile to be able to develop in a Container

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,39 @@
+{
+	"name": "Existing Dockerfile",
+
+	// Sets the run context to one level up instead of the .devcontainer folder.
+	"context": "..",
+
+	// Update the 'dockerFile' property if you aren't using the standard 'Dockerfile' filename.
+	"dockerFile": "../Dockerfile",
+
+	// Set *default* container specific settings.json values on container create.
+	"settings": { 
+		"terminal.integrated.shell.linux": "/bin/zsh"
+	},
+
+	// Add the IDs of extensions you want installed when the container is created.
+	"extensions": [
+		"coenraads.bracket-pair-colorizer-2",
+		"aaron-bond.better-comments",
+		"eamodio.gitlens",
+		"surendrajat.apklab",
+		"loyieking.smalise"
+	],
+	"workspaceFolder": "/root/home/apkLab-Results"
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Uncomment the next line to run commands after the container is created - for example installing curl.
+	// "postCreateCommand": "apt-get update && apt-get install -y curl",
+
+	// Uncomment when using a ptrace-based debugger like C++, Go, and Rust
+	// "runArgs": [ "--cap-add=SYS_PTRACE", "--security-opt", "seccomp=unconfined" ],
+
+	// Uncomment to use the Docker CLI from inside the container. See https://aka.ms/vscode-remote/samples/docker-from-docker.
+	// "mounts": [ "source=/var/run/docker.sock,target=/var/run/docker.sock,type=bind" ],
+
+	// Uncomment to connect as a non-root user if you've added one. See https://aka.ms/vscode-remote/containers/non-root.
+	// "remoteUser": "vscode"
+}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,69 @@
+# Download the Required Hacking Tools
+FROM alpine:latest as alpine-downloader
+
+ENV HACKTOOLS_DIR=/root/.apklab
+
+WORKDIR $HACKTOOLS_DIR
+
+# Install adb tools, unzip, wget, signapk and apktool
+RUN apk add wget unzip
+
+# Install SignApk
+RUN wget --no-check-certificate --quiet -O $HACKTOOLS_DIR/uber-apk-signer-1.1.0.jar https://github.com/patrickfav/uber-apk-signer/releases/download/v1.1.0/uber-apk-signer-1.1.0.jar
+
+# Install jadx
+RUN wget --no-check-certificate --quiet https://github.com/skylot/jadx/releases/download/v1.1.0/jadx-1.1.0.zip && \
+    mkdir -p $HACKTOOLS_DIR/jadx && \
+    unzip jadx-1.1.0.zip -d $HACKTOOLS_DIR/jadx && rm jadx-1.1.0.zip
+
+# Download apktool-2 & Rename downloaded jar to apktool.jar
+RUN wget --no-check-certificate --quiet -O $HACKTOOLS_DIR/apktool_2.4.1.jar https://bitbucket.org/iBotPeaches/apktool/downloads/apktool_2.4.1.jar
+
+
+
+# Pull Ubuntu LTS image.
+FROM shostarson/base-dev-env:v1
+
+# Labels and Credits
+LABEL \
+    name="Apk Lab Env" \
+    author="Rémi Lavedrine <twitter.com/shostarsson>" \
+    maintainer="Rémi Lavedrine <twitter.com/shostarsson>" \
+    description="A Docker Container that has everything ready to use the APKLab VSCode extension in a Dev Container."
+
+ENV SRC_DIR=/root/home/apkLab-Results
+ENV HACKTOOLS_DIR=/root/.apklab
+
+ENV APKTOOL=apktool_2.4.1.jar
+ENV UBER_APK_SIGNER=uber-apk-signer-1.1.0.jar
+
+WORKDIR $SRC_DIR
+
+COPY ./*.apk $SRC_DIR
+
+# Install adb tools, unzip, wget, signapk and apktool
+RUN apt update -y && apt install -y --no-install-recommends \
+    openjdk-8-jdk \
+    usbutils \
+    unzip \
+    wget \
+    android-tools-adb \
+    bash-completion \
+    gcc
+
+
+# Copy uber-apk-signer
+COPY --from=alpine-downloader $HACKTOOLS_DIR/$UBER_APK_SIGNER $HACKTOOLS_DIR/$UBER_APK_SIGNER
+RUN chmod +x $HACKTOOLS_DIR/$UBER_APK_SIGNER
+
+# Copy apktool
+COPY --from=alpine-downloader $HACKTOOLS_DIR/$APKTOOL $HACKTOOLS_DIR/$APKTOOL
+RUN chmod +x $HACKTOOLS_DIR/$APKTOOL
+
+# Copy jadx
+COPY --from=alpine-downloader $HACKTOOLS_DIR/jadx/bin/jadx $HACKTOOLS_DIR/jadx
+RUN chmod +x $HACKTOOLS_DIR/jadx
+
+
+RUN mkdir -p $SRC_DIR/.vscode/ && \
+    echo "{\n\t\"apklab.apktoolPath\": \"/root/.apklab/apktool_2.4.1.jar\",\n\t\"apklab.jadxDirPath\": \"/root/.apklab/jadx-1.1.0\",\n\t\"apklab.apkSignerPath\": \"/root/.apklab/uber-apk-signer-1.1.0.jar\"\n}" >> $SRC_DIR/.vscode/settings.json


### PR DESCRIPTION
This Container is supposed to be used with the VSCode Remote Container extension.

➜ It has every required tools ready to be used at the proper location.
➜ It copies inside the container all the .apk files that are in the folder where you start the Remote Container extension.
➜ You can either attach a running container or build it from the Dockerfile.

Add the VSCode devcontainer.json file

➜ The devcontainer.json file describes everything we want to install in the VSCode development container.

Signed-off-by: Rémi Lavedrine

---

So now, `apktool`, `jadx` and `uber-apk-signer` are not downloaded and installed somewhere on your machine, but everything stays in the Container and is already downloaded at the proper location within the container.

It works like a charm. 👌🏼
I launched it with InsecureBankv2.apk in the folder and everything was decoded perfectly. 👍🏼