### PR TITLE
apk-mitm: allow cleartext traffic and use unique nsc file name

### DIFF
--- a/src/mitm-tools.ts
+++ b/src/mitm-tools.ts
@@ -13,13 +13,11 @@ import { quickPickUtil } from './quick-pick.util';
 
 const DEFAULT_CONFIG = `<?xml version="1.0" encoding="utf-8"?>
 <network-security-config>
-    <debug-overrides>
-        <base-config cleartextTrafficPermitted="true">
-            <trust-anchors>
-                <certificates src="user" />
-            </trust-anchors>
-        </base-config>
-    </debug-overrides>
+    <base-config cleartextTrafficPermitted="true">
+        <trust-anchors>
+            <certificates src="user" />
+        </trust-anchors>
+    </base-config>
 </network-security-config>`;
 
 const INTERFACE_LINE = '.implements Ljavax/net/ssl/X509TrustManager;';
@@ -162,7 +160,7 @@ export namespace mitmTools {
             outputChannel.appendLine("-".repeat(report.length));
 
             const decodeDir = path.dirname(apktoolYmlPath);
-            
+
             await createNetworkSecurityConfig(decodeDir);
             await disableCertificatePinning(decodeDir);
 


### PR DESCRIPTION
Import patches: https://github.com/shroudedcode/apk-mitm/commit/b71ae57910d4739651fd2bc8b01cd35eda8a70c7 https://github.com/shroudedcode/apk-mitm/commit/6e0ed4ca7dd3500b32034725f7409c5119fff76c
Closes [apk-mitm-issue#29](https://github.com/shroudedcode/apk-mitm/issues/29) 