### PR TITLE
update tsc target to ES2019

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,11 +1,9 @@
 {
     "compilerOptions": {
         "module": "commonjs",
-        "target": "es6",
+        "target": "ES2019",
         "outDir": "out",
-        "lib": [
-            "es6"
-        ],
+        "lib": ["ES2019"],
         "sourceMap": true,
         "rootDir": "src",
         "resolveJsonModule": true,


### PR DESCRIPTION
Since VS Code uses Node.js 12 and according to [this wiki](https://github.com/microsoft/TypeScript/wiki/Node-Target-Mapping) it `ES2019` should work fine. 