### PR TITLE
CI: enable macOS and Windows tests

### DIFF
--- a/.github/workflows/apklab.yml
+++ b/.github/workflows/apklab.yml
@@ -36,11 +36,15 @@ jobs:
         if: contains(matrix.os, 'ubuntu') && matrix.node == 12
         run: npm run lint
       - name: Run tests
-        if: contains(matrix.os, 'ubuntu') && matrix.node == 12
-        run: xvfb-run -a npm test
-      - name: Run tests
-        if: runner.os != 'Linux' && matrix.node == 12
-        run: npm test
+        if: matrix.node == 12
+        shell: bash
+        run: |
+          if [[ "${{ runner.os }}" = "Linux" ]]
+          then
+            xvfb-run -a npm test
+          else
+            npm test
+          fi
       - name: Package extension
         run: npm run package
       - uses: actions/upload-artifact@v2

--- a/.github/workflows/apklab.yml
+++ b/.github/workflows/apklab.yml
@@ -38,6 +38,9 @@ jobs:
       - name: Run tests
         if: contains(matrix.os, 'ubuntu') && matrix.node == 12
         run: xvfb-run -a npm test
+      - name: Run tests
+        if: contains(matrix.os, 'windows') && matrix.node == 12
+        run: npm test
       - name: Package extension
         run: npm run package
       - uses: actions/upload-artifact@v2

--- a/.github/workflows/apklab.yml
+++ b/.github/workflows/apklab.yml
@@ -11,7 +11,7 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [macos-latest, ubuntu-latest, windows-latest]
         node: [12, 14]
       fail-fast: false
     runs-on: ${{ matrix.os }}
@@ -39,7 +39,7 @@ jobs:
         if: contains(matrix.os, 'ubuntu') && matrix.node == 12
         run: xvfb-run -a npm test
       - name: Run tests
-        if: contains(matrix.os, 'windows') && matrix.node == 12
+        if: runner.os != 'Linux' && matrix.node == 12
         run: npm test
       - name: Package extension
         run: npm run package

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -3,7 +3,6 @@
 out/**
 src/**
 .gitignore
-vsc-extension-quickstart.md
 **/tsconfig.json
 **/.eslintrc.json
 **/*.map
@@ -13,3 +12,5 @@ node_modules
 tsconfig.json
 webpack.config.js
 .github/
+testdata
+.*


### PR DESCRIPTION
Since we follow PR model now, slow macOS builds are not an issue. Also now that we have basic tests in place, having these enabled for all OSs shouldn't hurt.