### PR TITLE
build: clean workspace before packaging

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -21,7 +21,7 @@
                 "--extensionTestsPath=${workspaceFolder}/out/test/suite/index"
             ],
             "outFiles": ["${workspaceFolder}/out/test/**/*.js"],
-            "preLaunchTask": "npm: compile"
+            "preLaunchTask": "npm: pretest"
         }
     ]
 }

--- a/package.json
+++ b/package.json
@@ -163,14 +163,14 @@
         }
     },
     "scripts": {
-        "vscode:prepublish": "webpack --mode production",
+        "vscode:prepublish": "npm run clean && webpack --mode production",
         "compile": "tsc -p ./",
         "lint": "eslint src --ext ts && prettier --check .",
         "fix": "prettier --write . && eslint src --ext ts --fix",
-        "pretest": "npm run compile",
+        "clean": "git clean -Xdf -e !node_modules -e !node_modules/**/* -e !.vscode-test -e !.vscode-test/**/*",
+        "pretest": "npm run clean && npm run compile",
         "test": "node ./out/test/runTest.js",
         "package": "vsce package",
-        "webpack": "webpack --mode development",
         "watch": "webpack --mode development --watch"
     },
     "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -168,7 +168,7 @@
         "lint": "eslint src --ext ts && prettier --check .",
         "fix": "prettier --write . && eslint src --ext ts --fix",
         "clean": "git clean -Xdf -e !node_modules -e !node_modules/**/* -e !.vscode-test -e !.vscode-test/**/*",
-        "pretest": "npm run clean && npm run compile",
+        "pretest": "npm run compile",
         "test": "node ./out/test/runTest.js",
         "package": "vsce package",
         "watch": "webpack --mode development --watch"


### PR DESCRIPTION
Introduces new `npm run clean` script to clean workspace from old `dist/`, `out/`, etc.

(cleans all `git` ignored files except `node_modules` and `.vscode-test`)

It will run before each `package` step so nothing unnecessary gets into vsix.