### PR TITLE
CI: update ubuntu image to ubuntu-20.04

### DIFF
--- a/.github/workflows/apklab.yml
+++ b/.github/workflows/apklab.yml
@@ -24,10 +24,10 @@ jobs:
           ]
         include:
           - name: lint
-            os: ubuntu-latest
+            os: ubuntu-20.04
             node: 12
           - name: linux-build-test
-            os: ubuntu-latest
+            os: ubuntu-20.04
             node: 12
             run_test: true
           - name: macos-build-test
@@ -39,7 +39,7 @@ jobs:
             node: 12
             run_test: true
           - name: node14-build
-            os: ubuntu-latest
+            os: ubuntu-20.04
             node: 14
 
     steps:


### PR DESCRIPTION
GitHub Actions will soon switch `ubuntu-latest` to `ubuntu-20.04` from current `ubuntu-18.04`. This PR is to test if we will be fine when that happens.
Ref: https://github.com/actions/virtual-environments/issues/1816