### PR TITLE
suppress git warning

### DIFF
--- a/src/tools.ts
+++ b/src/tools.ts
@@ -155,7 +155,7 @@ export async function initGitDir(
             gitignore
         );
         let initCmd = `cd "${dirPath}" && git init && git config core.safecrlf false`;
-        initCmd += ` && git add -A && git commit - q - m "${commitMsg}"`;
+        initCmd += ` && git add -A && git commit -q -m "${commitMsg}"`;
         const report = `Initializing ${dirPath} as Git repository`;
         await executeProcess({
             name: "Initializing Git",

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -154,7 +154,8 @@ export async function initGitDir(
             path.join(dirPath, ".gitignore"),
             gitignore
         );
-        const initCmd = `cd "${dirPath}" && git init && git add -A && git commit -m "${commitMsg}"`;
+        let initCmd = `cd "${dirPath}" && git init && git config core.safecrlf false`;
+        initCmd += ` && git add -A && git commit - q - m "${commitMsg}"`;
         const report = `Initializing ${dirPath} as Git repository`;
         await executeProcess({
             name: "Initializing Git",


### PR DESCRIPTION
This will reduce the amount of logs produced by git in the output channel.

For `git add`, I've used `git config core.safecrlf false` ([refence](https://stackoverflow.com/a/14640908)) and for `git commit`, I've used `-q` option.

Needs testing on Windows.