### PR TITLE
CI: simplify quark-engine installation

### DIFF
--- a/.github/workflows/apklab.yml
+++ b/.github/workflows/apklab.yml
@@ -70,13 +70,7 @@ jobs:
         if: matrix.run_test == true
         shell: bash
         run: |
-          if [ "$RUNNER_OS" == "Linux" ]; then
-            pip install -U quark-engine
-          elif [ "$RUNNER_OS" == "Windows" ]; then
-            pip install -U quark-engine
-          else
-            pip install -U quark-engine
-          fi
+          pip install -U quark-engine
           # get quark-engine rules
           freshquark
           # check if it installed properly


### PR DESCRIPTION
After using `action/setup-python` few of the checks & steps are now redundant and have no place here anymore. 