### PR TITLE
Update smali debug .line info from JADX output for better debugging

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,6 +72,10 @@
             {
                 "command": "apklab.quarkReport",
                 "title": "APKLab: Show Quark analysis report"
+            },
+            {
+                "command": "apklab.updateSmaliLines",
+                "title": "APKLab: Update Smali Lines from Decompiled Source"
             }
         ],
         "menus": {
@@ -91,6 +95,10 @@
                 {
                     "command": "apklab.quarkReport",
                     "when": "false"
+                },
+                {
+                    "command": "apklab.updateSmaliLines",
+                    "when": "false"
                 }
             ],
             "editor/context": [
@@ -108,6 +116,11 @@
                     "command": "apklab.quarkReport",
                     "when": "resourceFilename == quarkReport.json",
                     "group": "navigation"
+                },
+                {
+                    "command": "apklab.updateSmaliLines",
+                    "when": "resourceFilename == apktool.yml",
+                    "group": "navigation"
                 }
             ],
             "editor/title": [
@@ -122,6 +135,11 @@
                 {
                     "command": "apklab.quarkReport",
                     "when": "resourceFilename == quarkReport.json"
+                },
+                {
+                    "command": "apklab.updateSmaliLines",
+                    "when": "resourceFilename == apktool.yml",
+                    "group": "navigation"
                 }
             ],
             "explorer/context": [
@@ -143,6 +161,11 @@
                 {
                     "command": "apklab.quarkReport",
                     "when": "resourceFilename == quarkReport.json",
+                    "group": "navigation"
+                },
+                {
+                    "command": "apklab.updateSmaliLines",
+                    "when": "resourceFilename == apktool.yml",
                     "group": "navigation"
                 }
             ]

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -8,6 +8,7 @@ import { apkMitm } from "./tools/apk-mitm";
 import { Quark } from "./tools/quark-engine";
 import { adb } from "./tools/adb";
 import { apktool } from "./tools/apktool";
+import { updateSmaliDebugLines } from "./utils/source-line-updater";
 
 export function activate(context: vscode.ExtensionContext): void {
     console.log("Activated apklab extension!");
@@ -46,6 +47,28 @@ export function activate(context: vscode.ExtensionContext): void {
                         "Can't download/update dependencies!"
                     );
                 });
+        }
+    );
+
+    const updateSmaliLines = vscode.commands.registerCommand(
+        "apklab.updateSmaliLines",
+        (uri: vscode.Uri) => {
+            vscode.window.withProgress(
+                {
+                    location: vscode.ProgressLocation.Notification,
+                    title: "Remapping smali line numbers",
+                    cancellable: false,
+                },
+                (progress) => {
+                    const p = new Promise<void>((resolve) => {
+                        updateSmaliDebugLines(uri.fsPath, progress).then(
+                            resolve
+                        );
+                    });
+
+                    return p;
+                }
+            );
         }
     );
 
@@ -93,7 +116,8 @@ export function activate(context: vscode.ExtensionContext): void {
         installAPkFileCommand,
         patchApkForHttpsCommand,
         emptyFrameworkDirCommand,
-        quarkReportCommand
+        quarkReportCommand,
+        updateSmaliLines
     );
 
     // check if open folder contains `quarkReport.json` file

--- a/src/tools/jadx.ts
+++ b/src/tools/jadx.ts
@@ -25,7 +25,14 @@ export namespace jadx {
         const apkDecompileDir = path.join(projectDir, "java_src");
         const apkFileName = path.basename(apkFilePath);
         const report = `Decompiling ${apkFileName} into ${apkDecompileDir}`;
-        let args = ["-r", "-q", "-ds", apkDecompileDir, apkFilePath];
+        let args = [
+            "-r",
+            "-q",
+            "--add-debug-lines",
+            "-ds",
+            apkDecompileDir,
+            apkFilePath,
+        ];
         if (jadxArgs && jadxArgs.length > 0) {
             args = jadxArgs.concat(args);
         }

--- a/src/utils/directory-utils.ts
+++ b/src/utils/directory-utils.ts
@@ -1,0 +1,39 @@
+import * as fs from "fs";
+import * as path from "path";
+
+export async function copyDirectory(src: string, dest: string): Promise<void> {
+    try {
+        await fs.promises.access(dest, fs.constants.F_OK);
+    } catch (error) {
+        await fs.promises.mkdir(dest, { recursive: true });
+    }
+
+    const entries = await fs.promises.readdir(src, { withFileTypes: true });
+
+    for (const entry of entries) {
+        const srcPath = path.join(src, entry.name);
+        const destPath = path.join(dest, entry.name);
+
+        if (entry.isDirectory()) {
+            await copyDirectory(srcPath, destPath);
+        } else {
+            await fs.promises.copyFile(srcPath, destPath);
+        }
+    }
+}
+
+export function getFullBaseName(filePath: string, directory: string): string {
+    const parsedPath = path.parse(filePath);
+    const pathNoExt = path.join(parsedPath.dir, parsedPath.name);
+
+    const baseName = pathNoExt.replace(directory, "");
+    return baseName.substring(1);
+}
+
+export function stripLeadingDir(filePath: string): string {
+    const baseParts = filePath.split("/");
+    const filteredPathParts = baseParts.filter((part) => part !== "");
+
+    filteredPathParts.shift();
+    return filteredPathParts.join("/");
+}

--- a/src/utils/source-line-updater.ts
+++ b/src/utils/source-line-updater.ts
@@ -1,0 +1,240 @@
+import * as fs from "fs";
+import * as path from "path";
+import * as vscode from "vscode";
+import {
+    copyDirectory,
+    getFullBaseName,
+    stripLeadingDir,
+} from "./directory-utils";
+
+class SourceSmaliMapping {
+    sourceFile: string;
+    smaliFile: string;
+    lineMap: Map<number, number>;
+
+    constructor(
+        sourceFile: string,
+        smaliFile: string,
+        lineMap: Map<number, number>
+    ) {
+        this.sourceFile = sourceFile;
+        this.smaliFile = smaliFile;
+        this.lineMap = lineMap;
+    }
+
+    public async updateSmaliFileLines(projectDir: string, newDir: string) {
+        await replaceLineNumbersInSmaliFile(
+            this.smaliFile,
+            this.lineMap,
+            projectDir,
+            newDir
+        );
+    }
+}
+
+export async function updateSmaliDebugLines(
+    apktoolYmlPath: string,
+    progress: vscode.Progress<{
+        message?: string | undefined;
+        increment?: number | undefined;
+    }>
+): Promise<void> {
+    progress.report({ increment: 0, message: "Starting smali mapping" });
+
+    const projectDir = path.parse(apktoolYmlPath).dir;
+    const sourceDir = path.join(projectDir, "java_src");
+
+    if (!fs.existsSync(sourceDir)) {
+        vscode.window.showErrorMessage(
+            "Java source file directory is not present, source files are compiled with sourcelines"
+        );
+        return;
+    }
+
+    const originSmaliDir = path.join(projectDir, "orig_smali");
+    const newSmaliDir = projectDir;
+
+    progress.report({ increment: 1, message: "Backing up original smalis" });
+
+    backupOrigSmalis(projectDir, originSmaliDir);
+
+    const sourceFiles = collectFilesWithExtension(sourceDir, "java");
+    const smaliFiles = collectFilesWithExtension(originSmaliDir, "smali");
+
+    progress.report({ increment: 5, message: "Getting linemappings" });
+
+    const sourceFileMappings = await collectSmaliFilesPairsForSourceFilesList(
+        sourceFiles,
+        smaliFiles,
+        sourceDir,
+        originSmaliDir
+    );
+
+    progress.report({
+        increment: 10,
+        message: "Updating smali line info from mappings",
+    });
+
+    let progressInt = 1;
+    const total = sourceFileMappings.length;
+    const interval = 1000;
+
+    const incAmount = 84 / (total / interval);
+
+    for (const sourceFileMapping of sourceFileMappings) {
+        if (progressInt % interval === 0) {
+            progress.report({
+                increment: incAmount,
+                message: `Writing smalis: ${progressInt} out of ${total}`,
+            });
+        }
+        progressInt++;
+        await sourceFileMapping.updateSmaliFileLines(
+            originSmaliDir,
+            newSmaliDir
+        );
+    }
+}
+
+async function replaceLineNumbersInSmaliFile(
+    smaliFile: string,
+    lineMap: Map<number, number>,
+    projectDir: string,
+    newDir: string
+) {
+    try {
+        const fileContent = await fs.promises.readFile(smaliFile, {
+            encoding: "utf-8",
+        });
+        const lines = fileContent.split("\n");
+        let lastMatch = 1;
+        const updatedLines = lines.map((line) => {
+            const match = line.match(/\.line (\d+)/);
+
+            if (match) {
+                const lineNumber = parseInt(match[1], 10);
+
+                if (lineMap.has(lineNumber)) {
+                    const newLineNumber = lineMap.get(lineNumber);
+                    lastMatch = newLineNumber as number;
+
+                    return line.replace(match[0], `.line ${newLineNumber}`);
+                } else {
+                    return line.replace(match[0], `.line ${lastMatch}`);
+                }
+            }
+            return line;
+        });
+
+        const updatedContent = updatedLines.join("\n");
+
+        const outpath = smaliFile.replace(projectDir, newDir);
+        const outDirPath = path.dirname(outpath);
+        if (!fs.existsSync(outDirPath)) {
+            fs.mkdirSync(outDirPath, { recursive: true });
+        }
+
+        await fs.promises.writeFile(outpath, updatedContent, {
+            encoding: "utf-8",
+        });
+    } catch (error) {
+        console.error(`Error processing file: ${(error as Error).message}`);
+    }
+}
+
+async function parseLineMapFromSourceFile(
+    sourceFile: string
+): Promise<Map<number, number>> {
+    const lineMap = new Map();
+    let sourceLine = 0;
+    try {
+        const fileContent = await fs.promises.readFile(sourceFile, {
+            encoding: "utf-8",
+        });
+        const lines = fileContent.split("\n");
+
+        for (const line of lines) {
+            sourceLine++;
+            const match = line.match(/^\/\* (\d+) \*\//);
+
+            if (match) {
+                const annotatedLineNumber = parseInt(match[1], 10);
+                lineMap.set(annotatedLineNumber, sourceLine);
+            }
+        }
+    } catch (err) {
+        console.error(`error on line ${sourceLine}`);
+        console.error(`Error processing file: ${(err as Error).message}`);
+    }
+
+    return lineMap;
+}
+
+function collectFilesWithExtension(
+    directory: string,
+    extension: string
+): string[] {
+    return fs.readdirSync(directory).flatMap((file: string) => {
+        const absolutePath = path.join(directory, file);
+
+        if (absolutePath.startsWith(".")) {
+            return [];
+        }
+
+        if (fs.statSync(absolutePath).isDirectory()) {
+            return collectFilesWithExtension(absolutePath, extension);
+        } else {
+            return absolutePath.split(".").pop() === extension
+                ? [absolutePath]
+                : [];
+        }
+    });
+}
+
+async function collectSmaliFilesPairsForSourceFilesList(
+    sourceFiles: string[],
+    smaliFiles: string[],
+    javaSrcDir: string,
+    smaliDir: string
+): Promise<SourceSmaliMapping[]> {
+    const smaliMap = new Map<string, string>();
+
+    for (const smaliFile of smaliFiles) {
+        const smaliPath = getFullBaseName(smaliFile, smaliDir);
+        const baseName = stripLeadingDir(smaliPath);
+
+        if (smaliMap.has(baseName)) {
+            console.log("dup smali, this should never happen");
+        } else {
+            smaliMap.set(baseName, smaliFile);
+        }
+    }
+
+    const sourceSmaliMappingArray: SourceSmaliMapping[] = [];
+    for (const sourceFile of sourceFiles) {
+        const javaFileName = getFullBaseName(sourceFile, javaSrcDir);
+
+        if (smaliMap.has(javaFileName)) {
+            const relatedSmaliFile = smaliMap.get(javaFileName) as string;
+            const lineMap = await parseLineMapFromSourceFile(sourceFile);
+            sourceSmaliMappingArray.push(
+                new SourceSmaliMapping(sourceFile, relatedSmaliFile, lineMap)
+            );
+        }
+    }
+    return sourceSmaliMappingArray;
+}
+
+function backupOrigSmalis(projectDir: string, originSmaliDir: string) {
+    if (!fs.existsSync(originSmaliDir)) {
+        fs.mkdirSync(originSmaliDir);
+
+        for (const directory of fs.readdirSync(projectDir)) {
+            if (directory.startsWith("smali")) {
+                const srcDir = path.join(projectDir, directory);
+                const destDir = path.join(originSmaliDir, directory);
+                copyDirectory(srcDir, destDir);
+            }
+        }
+    }
+}


### PR DESCRIPTION
When debugging decompiled source there are challenges and various annoyances due to discrepancies between the line numbers in the "debug_info_item" structures of the Dex files and those in the decompiled source code. This discrepancy arises because the process of decompilation usually does not produce an accurate representation of the original source code. These inconsistencies can make it difficult to map the source code to the bytecode, leading to misleading breakpoints, inaccurate step-by-step execution, and confusion in interpreting variable values and exception handling. 

This PR adds a feature where the .line debug information in the smali files is updated to match the lines of JADX decompiled source code, making it easier to trace the execution flow of the application and understand its behavior. This significantly improves the debugging process when working with APKs where the original source code is not available.

This is enabled by the JADX '--add-debug-lines' flag which includes original source line information from the dex as comments in the decompiled code. This extension will parse these debug sourcelinie comments, map them to the line they appear in the decompiled source file, and apply these mappings by updatingthe associated smali files. 

The core function of the fork is implemented in the updateSmaliDebugLines function, which is triggered from the context menu when right-clicking the apktool.yml file. The function starts by determining the project directory and the java decompiled sources directory. If the java source directory does not exist, the task aborts. Otherwise, the function proceeds to back up the original smali files, collect all source and smali files, and create mappings between them based on the line comments in the decompiled code from JADX. Finally, it iterates through the mappings and updates the smali file line information according to the JADX decompiled source code.

