### PR TITLE
fix: fetch the tool update config from raw.githubusercontent (reachable from CI)

### DIFF
--- a/src/data/constants.ts
+++ b/src/data/constants.ts
@@ -27,7 +27,7 @@ export const apklabDataDir = path.join(os.homedir(), ".apklab");
  * URL to get the updater JSON data
  */
 export const updaterConfigURL =
-    "https://apklab.surendrajat.xyz/apklab_update_config.json";
+    "https://raw.githubusercontent.com/APKLab/website/refs/heads/master/static/apklab_update_config.json";
 
 /**
  * File extensions

--- a/src/utils/updater.ts
+++ b/src/utils/updater.ts
@@ -163,39 +163,36 @@ export async function updateTools(): Promise<void> {
  * If any tool does not exist, download it.
  */
 export async function checkAndInstallTools(): Promise<void> {
-    try {
-        const config = await getUpdateConfig();
+    const config = await getUpdateConfig();
+    if (!config.tools || config.tools.length === 0) {
+        throw new Error("APKLab: no tools found in the update config");
+    }
 
-        const results = await Promise.allSettled(
-            config.tools.map(async (tool) => {
-                if (isToolInstalled(tool)) {
-                    // present on disk: repair a missing/stale config value
-                    await syncToolConfig(tool);
-                    return;
-                }
-                const filepath = await downloadTool(tool);
-                if (!filepath) {
-                    throw new Error(`Failed to download tool: ${tool.name}`);
-                }
-                if (tool.name === "apktool") {
-                    // remove old res framework on apktool install
-                    await apktool.emptyFrameworkDir();
-                }
-            }),
-        );
+    const results = await Promise.allSettled(
+        config.tools.map(async (tool) => {
+            if (isToolInstalled(tool)) {
+                await syncToolConfig(tool);
+                return;
+            }
+            await downloadTool(tool);
+            if (!isToolInstalled(tool)) {
+                throw new Error(
+                    `could not install ${tool.name} from ${tool.downloadUrl}`,
+                );
+            }
+            if (tool.name === "apktool") {
+                await apktool.emptyFrameworkDir();
+            }
+        }),
+    );
 
-        // Check if any downloads failed
-        const failures = results.filter(
-            (result) => result.status === "rejected",
-        );
-        if (failures.length > 0) {
-            const errors = failures
-                .map((f) => (f as PromiseRejectedResult).reason)
-                .join(", ");
-            outputChannel.appendLine(`Failed to install some tools: ${errors}`);
-        }
-    } catch (err) {
-        outputChannel.appendLine(`Can't download/update dependencies: ${err}`);
+    const failures = results
+        .filter((r) => r.status === "rejected")
+        .map((r) => String((r as PromiseRejectedResult).reason));
+    if (failures.length > 0) {
+        const msg = `APKLab: failed to install tools: ${failures.join("; ")}`;
+        outputChannel.appendLine(msg);
+        throw new Error(msg);
     }
 }
 


### PR DESCRIPTION
## Problem

The tool list is fetched at runtime from `apklab.surendrajat.xyz`, which is behind Cloudflare and gets blocked from the CI runners. The fetch failed, `getUpdateConfig()` returned an empty list, and `checkAndInstallTools()` silently resolved — so no tools installed and every tool-dependent test failed, while the run still logged `Tools Installed!`. (The passing tests don't need the runtime tools; quark is installed via a separate `pip` step.)

## Fix

- Point `updaterConfigURL` at the **same config file on `raw.githubusercontent.com`** (identical content, but reachable from CI — no Cloudflare). This is the root-cause fix.
- `checkAndInstallTools()` now verifies each tool actually landed on disk and **throws** if any didn't, so a failed install can't be reported as `Tools Installed!` again.

No bundled fallback / User-Agent / redirect changes — those were working around the Cloudflare block, which switching hosts removes.

## Verification

- Locally: fresh install fetches the config from the raw URL and installs all 4 tools; with the network blocked, `checkAndInstallTools()` throws instead of resolving.
- CI on this branch.